### PR TITLE
Make detailed dial logging optional with a command-line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ ipfs-crawl
 
 This will run indefinitely and generate a file `ipfs-crawl.out` in the
 current directory, logging (in json) the results of connection attemps
-to peers discovered during the crawl. A detailed dial event log will
-be written in `ipfs-crawl-events.json`.
+to peers discovered during the crawl.
+
+If you want detailed dial logs, then invoke the crawler with:
+```
+ipfs-crawl -log-dial
+```
+This will log all dial events to `ipfs-crawl-events.json` in the current
+directory.
 
 Note: You should make sure your file descriptor ulimit is sufficiently
 high to potentially connect to all the reachable peers. The network is

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"time"
 
@@ -12,12 +13,17 @@ import (
 )
 
 func main() {
+	logDial := flag.Bool("log-dial", false, "Log dial events in ipfs-crawl-events.json")
+	flag.Parse()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err := NewEventsLogger("ipfs-crawl-events.json")
-	if err != nil {
-		log.Fatal(err)
+	if *logDial {
+		_, err := NewEventsLogger("ipfs-crawl-events.json")
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	out, err := NewCrawlLog("ipfs-crawl.out")


### PR DESCRIPTION
See #4, but also cpu usage from event log parsing.